### PR TITLE
Remove section that disallows using shorthand operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -247,7 +247,7 @@
     "max-params": 0, //limits the number of parameters that can be used in the function declaration.
     "max-statements": 0, //specify the maximum number of statement allowed in a function
     "no-bitwise": 1, //disallow use of bitwise operators
-    "no-plusplus": 1, //disallow use of unary operators, ++ and --
+    "no-plusplus": 0, //allow use of unary operators, ++ and --
 
     /* React */
     "react/display-name": 0, //Prevent missing displayName in a React component definition

--- a/es6.md
+++ b/es6.md
@@ -340,18 +340,6 @@ t.y = 4;
 
 ## Operators
 
-- Short-hand operators `+=`-like and `++`-like operators **must not** be used. Also, consider refactoring to get rid of the underlying `let`.
-
-```js
-let n = 0;
-// bad
-n += 1;
-n++;
-
-// good
-n = n + 1;
-```
-
 - Non-strict comparison operators `==` or `!=` **must not** be used. Strict comparison operators `===` or `!==` **must** be used instead.
 
 - Boolean force-casting `!!expr` **should not** be used. `expr` **should** BE used directly, unless you specifically care about leaking values in a function call or a return value.


### PR DESCRIPTION
In our discussion, we all agreed that we like being able to use `++` and `+= ...`.