### PR TITLE
Change else if style

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -575,7 +575,7 @@ const id = (x) => x;
 
 ## if/else construct
 
-- `if`/`else if`/`else` **must** be preceded by a newline.
+- `if`/`else if`/`else` **must not** be preceded by a newline.
 
 ```js
 // bad
@@ -590,11 +590,9 @@ if (...) {
 // good
 if (...) {
   ...
-}
-else if {
+} else if {
   ...
-}
-else {
+} else {
   ...
 }
 ```


### PR DESCRIPTION
The original style guide required having a newline before `else if`. In our discussion, we all agreed we prefer the opposite.