### PR TITLE
Change if whitespace style to include a space

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -211,10 +211,7 @@
     "semi-spacing": [1, { "before": false, "after": true }], //enforce spacing before and after semicolons
     "semi": [1, "always"], //require or disallow use of semicolons instead of ASI (fixable)
     "sort-vars": 0, //sort variables within the same declaration block
-    "space-after-keywords": 0, //require a space after certain keywords (fixable)
-    "space-before-blocks": [1, "always"], //require or disallow a space before blocks (fixable)
-    "space-before-function-paren": [1, "never"], //require or disallow a space before function opening parenthesis (fixable)
-    "space-before-keywords": [0, "never"], //require a space before certain keywords (fixable)
+    "keyword-spacing": 1,
     "space-in-parens": [1, "never"], //require or disallow spaces inside parentheses
     "space-infix-ops": 1, //require spaces around operators (fixable)
     "space-return-throw-case": 1, //require a space after return, throw, and case (fixable)

--- a/es6.md
+++ b/es6.md
@@ -425,16 +425,16 @@ const a = [ 1, 2 ];
 const a = [1, 2];
 ```
 
-- Space **must not** be used before the leading paren `(`.
+- Space **must** be used before the leading paren `(`.
 
 ```js
 // bad
-if (true) {
+if(true) {
   ...
 }
 
 // good
-if(true) {
+if (true) {
   ...
 }
 ```

--- a/es6.md
+++ b/es6.md
@@ -54,7 +54,7 @@ function Constructor() { ... }
 class Class { ... }
 const Namespace = {};
 
-if(__MACRO__) { ... }
+if (__MACRO__) { ... }
 const SOME_MAGIC_NUMBER = 1337;
 const {
   _privateMethod() {
@@ -346,12 +346,12 @@ t.y = 4;
 
 ```js
 // bad
-if(!!expr) {
+if (!!expr) {
   ...
 }
 
 // good
-if(expr) {
+if (expr) {
   ...
 }
 
@@ -379,12 +379,12 @@ someUntrustedFunction(!!expr);
 
 ```js
 // bad
-if(true) {
+if (true) {
     return 42;
 }
 
 // good
-if(true) {
+if (true) {
   return 42;
 }
 ```
@@ -393,12 +393,12 @@ if(true) {
 
 ```js
 // bad
-if(true){
+if (true){
   ...
 }
 
 // good
-if(true) {
+if (true) {
   ...
 }
 ```
@@ -513,14 +513,14 @@ a.then(...)
 
 ```js
 // bad
-if(true)
+if (true)
  return 42;
-if(true) return 42;
+if (true) return 42;
 const id = (x) => { return x; };
 
 // good
-if(true) { return 42; }
-if(true) {
+if (true) { return 42; }
+if (true) {
   return 42;
 }
 const id = (x) => x;
@@ -579,16 +579,16 @@ const id = (x) => x;
 
 ```js
 // bad
-if(...) {
+if (...) {
   ...
-} else if(...) {
+} else if (...) {
   ...
 } else {
   ...
 }
 
 // good
-if(...) {
+if (...) {
   ...
 }
 else if {
@@ -855,7 +855,7 @@ p.then(() => {
 });
 
 function f() {
-  if(...) {
+  if (...) {
     return Promise.resolve(...);
   }
   else {
@@ -873,7 +873,7 @@ p.then(() => {
 
 function f() {
   return Promise.try(() => {
-    if(...) {
+    if (...) {
       return ...;
     }
     else {
@@ -892,20 +892,20 @@ function f() {
 ```js
 // bad
 function odd(n) {
-  if(n === 0) {
+  if (n === 0) {
     return false;
   }
-  if(n === 1) {
+  if (n === 1) {
     return true;
   }
   return !even(n-1);
 }
 
 function even(n) {
-  if(n === 0) {
+  if (n === 0) {
     return true;
   }
-  if(n === 1) {
+  if (n === 1) {
     return false;
   }
   return !odd(n-1);
@@ -914,7 +914,7 @@ function even(n) {
 // good
 function factorial(n) {
   function factorialLoop(n, acc) {
-    if(n === 1) {
+    if (n === 1) {
       return acc;
     }
     else {


### PR DESCRIPTION
There was some disagreement about this one in our discussion.

I realize I may be outvoted on here, but I thought I would start the pull-request as a place to vote/discuss preferences on whitespace after `if`.

Since many of the examples contain `if` statements, this pull-request contains a lot of changes other than the actual rule. The actual rule change can be found here: 0a617a2c89b0ff11024401820ddf3deb7242390b.