### PR TITLE
Add a statement in the style-guide about trailing whitespace

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -496,6 +496,8 @@ const a = b + c;
 
 - Files **must** end with a single newline character.
 
+- Files **must not** contain trailing whitespace.
+
 - Leading dot and proper indentation **must** be used for method chaining.
 
 ```js


### PR DESCRIPTION
This is already enforced in `.eslintrc`.