### PR TITLE
Moved example ternary from acceptable to bad

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -633,8 +633,6 @@ const foo = fooBar(bar + qux) * qux ? fooBar(barFoo({ bar })[qux]).foo : fooBar(
 
 // bad
 const foo = qux ? (bar ? qux : baz) : bar;
-
-// acceptable
 const foo = bar === baz ? bar + 1 : baz - 1;
 
 // good

--- a/es6.md
+++ b/es6.md
@@ -630,8 +630,6 @@ aFunctionWithALongNameCalledIfTheFirstExpressionIsFalse();
 
 // bad
 const foo = fooBar(bar + qux) * qux ? fooBar(barFoo({ bar })[qux]).foo : fooBar(barFoo({ qux })[foo]).baz;
-
-// bad
 const foo = qux ? (bar ? qux : baz) : bar;
 const foo = bar === baz ? bar + 1 : baz - 1;
 


### PR DESCRIPTION
Per notes from our meeting yesterday, I marked the `const foo = bar === baz ? bar + 1 : baz - 1;` ternary example as `bad` rather than `acceptable`.