### PR TITLE
disable no-class-assign

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -224,7 +224,7 @@
     "arrow-spacing": [1, { "before": true, "after": true }], //require space before/after arrow function's arrow (fixable)
     "constructor-super": 1, //verify calls of super() in constructors
     "generator-star-spacing": [1, "after"], // enforce spacing around the * in generator functions (fixable)
-    "no-class-assign": 1, //disallow modifying variables of class declarations
+    "no-class-assign": 0, //disallow modifying variables of class declarations
     "no-const-assign": 1, //disallow modifying variables that are declared using const
     "no-dupe-class-members": 1, //disallow duplicate name in class members
     "no-this-before-super": 1, //disallow use of this/super before calling super() in constructors.


### PR DESCRIPTION
When working with Relay and React the convention is to make components like this

```javascript
class Quiz extends React.Component {
  ...
}
```

and then define the data needs in relay like so:
```javascript
Quiz = Relay.createContainer(Quiz, {
  fragments: {
    quiz: () => Relay.QL`
      fragment on Quiz {
        facebook_page_id
        questions {
          text
        }
        results {
          min,
          max,
          identifier
        }
      }
    `
  }
});
```

Currently ESLlint yells because of `no-class-assign`. Seems safe enough of a rule to disable.