### PR TITLE
Add es6 to ESLint env

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     "jsx": true
   },
   "env": {
+    "es6": true,
     "browser": true,
     "node": true,
     "mocha": true,


### PR DESCRIPTION
This enables es6 in the env.  

I noticed this because the `Reflect` API was being caught as undefined in ES6.