### PR TITLE
Prefer trailing dots over leading dots

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -521,27 +521,10 @@ style guide.
   ```
 
 * <a name="consistent-multi-line-chains"></a>
-    Adopt a consistent multi-line method chaining style. There are two popular
-    styles in the Ruby community, both of which are considered
-    good&mdash;leading `.` (Option A) and trailing `.` (Option B).
+  When continuing a chained method invocation on another line,
+  include the `.` on the first line to indicate that the
+  expression continues.
 <sup>[[link](#consistent-multi-line-chains)]</sup>
-
-  * **(Option A)** When continuing a chained method invocation on
-    another line keep the `.` on the second line.
-
-    ```ruby
-    # bad - need to consult first line to understand second line
-    one.two.three.
-      four
-
-    # good - it's immediately clear what's going on the second line
-    one.two.three
-      .four
-    ```
-
-  * **(Option B)** When continuing a chained method invocation on another line,
-    include the `.` on the first line to indicate that the
-    expression continues.
 
     ```ruby
     # bad - need to read ahead to the second line to know that the chain continues
@@ -553,7 +536,7 @@ style guide.
       four
     ```
 
-  A discussion on the merits of both alternative styles can be found
+  A discussion on the merits of alternative styles can be found
   [here](https://github.com/bbatsov/ruby-style-guide/pull/176).
 
 * <a name="no-double-indent"></a>


### PR DESCRIPTION
The community styleguide did not pick one and instead encourages teams to pick one.

There is a lengthy discussion here: https://github.com/bbatsov/ruby-style-guide/pull/176 and is a pretty interesting read.

Note that this only applies to ruby.

What are we talking about?
--------------------------

To clarify, here's what we're talking about:

```ruby
  # trailing dots
  one.two.three.
    four

  # leading dots
  one.two.three
    .four
```

My argument
-----------

Having read through the discussion, I propose we use trailing dots.

It seems like the arguments can be oversimplified to mostly ([source](https://github.com/bbatsov/ruby-style-guide/pull/176#issuecomment-24642801):

* leading dots is more visually pleasing
* trailing dots has more functional advantages

Here are some of the arguments I like:

* Basically, when continuing lines like this, you need context on both lines. Using the trailing dot gives context on the first line, indentation gives context on the second line ([source](https://github.com/bbatsov/ruby-style-guide/pull/176#issuecomment-18755860)).
* Code written with leading dots cannot be pasted in to irb/pry ([source](https://github.com/bbatsov/ruby-style-guide/pull/176#issuecomment-20421523)).
* Loading dots are easier for parsers ([source](https://github.com/bbatsov/ruby-style-guide/pull/176#issuecomment-32788590)).
* There are some scenarios in which leading dots can cause bugs ([source](https://github.com/bbatsov/ruby-style-guide/pull/176#issuecomment-32786858)).