### PR TITLE
Add services and observers to the ordering section

### DIFF
--- a/ember.md
+++ b/ember.md
@@ -252,32 +252,41 @@ function _someUtilityFunction() {
 Ordering a module's properties in a predictable manner will make it easier to
 scan.
 
-1. __Plain properties__
+1. __Service Injections__ (`service`)
+
+2. __Plain properties__ (`property`)
 
    Start with properties that configure the module's behavior. Examples are
    `tagName` and `classNames` on components and `queryParams` on controllers and
    routes. Followed by any other simple properties, like default values for properties.
 
-2. __Single line computed property macros__
+3. __Single line computed property macros__ (`single-line-function`)
 
    E.g. `readOnly`, `sort` and other macros. Start with service injections. If the
    module is a model, then `attr` properties should be first, followed by
    `belongsTo` and `hasMany`.
 
-3. __Multi line computed property functions__
+4. __Multi line computed property functions__ (`multi-line-function`)
 
-4. __Lifecycle hooks__
+5. __Observers__ (`observer`)
+
+   We try not to use observers, but if we do, they should go here.
+
+6. __Lifecycle hooks__ (`lifecycle-hooks`),
 
    The hooks should be chronologically ordered by the order they are invoked in.
 
-5. __Functions__
+7. __Functions__ (`method`)
 
    Public functions first, internal functions after.
 
-6. __Actions__
+8. __Actions__ (`actions`)
 
 ```js
 export default Ember.Component.extend({
+  // Service Injections
+  session: inject.service(),
+
   // Plain properties
   tagName: 'span',
 


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/150719204)

In the Ember styleguide we have a section proclaiming a specific order for properties in Ember modules. This order had nothing about services or observers.

This change is part of an effort to move us towards a styleguide that is compatible with the [ember eslint plugin][] so that we can use it to enforce these rules.

The ordering I chose is based on the defaults in the plugin. The plugin handles components, controllers, models, and routes differently. For a general sense of the plugin order, check out the [order in components][] documentation.

It _is_ possible to configure the plugin to enforce a different order from the defaults. However, I would prefer to stick with the default unless there are very strong opinions otherwise. Using the default simplifies our configuration and aligns us with the rest of the community.

[order in components]: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/order-in-components.md
[ember eslint plugin]: https://github.com/ember-cli/eslint-plugin-ember/

Incidental
----

To each item in the ordering section, I added the identifier used by the plugin. I thought this might help cross reference the plugin configuration.

Notes
---

* I did not add observers to the example because using observers is an anti-pattern. If we _need_ them, they have a place in the order...

* I will not merge this until approved by the following people, as they use Ember the most:

  * @andreafrost 
  * @maprules1000 
  * @kculafic 