### PR TITLE
Switch functions and actions in the ember ordering rules

### DIFF
--- a/ember.md
+++ b/ember.md
@@ -290,6 +290,7 @@ export default Ember.Component.extend({
 
   // Plain properties
   tagName: 'span',
+  classNames: w('as-button'),
 
   // Single line CP
   post: readOnly('myPost'),

--- a/ember.md
+++ b/ember.md
@@ -276,11 +276,12 @@ scan.
 
    The hooks should be chronologically ordered by the order they are invoked in.
 
-7. __Functions__ (`method`)
+7. __Actions__ (`actions`)
+
+8. __Functions__ (`method`)
 
    Public functions first, internal functions after.
 
-8. __Actions__ (`actions`)
 
 ```js
 export default Ember.Component.extend({
@@ -304,6 +305,12 @@ export default Ember.Component.extend({
     // Code
   },
 
+  actions: {
+    someAction() {
+      // Code
+    },
+  },
+
   // Functions
   someFunction() {
     // Code
@@ -311,12 +318,6 @@ export default Ember.Component.extend({
 
   _privateInternalFunction() {
     // Code
-  },
-
-  actions: {
-    someAction() {
-      // Code
-    },
   },
 });
 


### PR DESCRIPTION
_This is the change I suggested might be controversial in standup._

[Pivotal Card](https://www.pivotaltracker.com/story/show/150719204)

In the Ember styleguide we have a section proclaiming a specific order for properties in Ember modules. I would like to start using [ember eslint plugin][] to enforce these rules. However, our styleguide has a very slightly different order than the default order enforced by the eslint plugin.

The only difference is at the very end. Our styleguide had internal functions and then actions. The plugin has [actions and then internal functions](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/order-in-components.md).

It _is_ possible to configure the plugin to enforce a different order from the defaults. However, I would prefer to stick with the default unless there are very strong opinions otherwise. Using the default simplifies our configuration and aligns us with the rest of the community.

So, what do you think, would you be ok with this change?

[ember eslint plugin]: https://github.com/ember-cli/eslint-plugin-ember/

Notes
---

* This PR is based on #6 to prevent conflicts and will be rebased after #6 is merged. Check out https://github.com/ActionSprout/coding-styles/pull/7/commits/2acd80134085c0a79611ad1659614e2d03f8471d to see only the change in this PR.

* I will not merge this until approved by the following people, as they use Ember the most:

  * @andreafrost
  * @maprules1000
  * @kculafic