### PR TITLE
Establish Order Conventions for organizing ember Models

### DIFF
--- a/ember.md
+++ b/ember.md
@@ -365,7 +365,7 @@ export default DS.Model.extend({
   children: hasMany('child'),
   
   // Properties
-  PeopleAgeBrackets: [
+  peopleAgeBrackets: [
     '18-24',
     '25-34',
     '35-44',

--- a/ember.md
+++ b/ember.md
@@ -362,6 +362,7 @@ export default DS.Model.extend({
   lastName: attr('string'),
 
   // Relationships
+  person: belongsTo('person'),
   children: hasMany('child'),
   
   // Properties

--- a/ember.md
+++ b/ember.md
@@ -341,9 +341,11 @@ order. [Don't Don't Override Init](https://dockyard.com/blog/2015/10/19/2015-don
 
 Models should be grouped as follows:
 
+* Services
 * Attributes
-* Associations
-* Computed Properties
+* Relationships
+* Properties
+* Computed Properties ('single-line-function' should be above 'multi-line-function')
 
 ```js
 // Good
@@ -359,10 +361,22 @@ export default DS.Model.extend({
   firstName: attr('string'),
   lastName: attr('string'),
 
-  // Associations
+  // Relationships
   children: hasMany('child'),
+  
+  // Properties
+  PeopleAgeBrackets: [
+    '18-24',
+    '25-34',
+    '35-44',
+    '45-54',
+    '55-64',
+    '65+',
+  ],
 
-  // Computed Properties
+  // Computed Properties (single-line functions above multi-line functions)
+  label: computed.readOnly('peopleDetails.label'),
+  
   fullName: computed('firstName', 'lastName', function _fullName() {
     // Code
   }),


### PR DESCRIPTION
Add `Services` and `Properties` to establish order conventions across ember models. 

These conventions will be re-asserted by ESLint (https://github.com/ember-cli/eslint-plugin-ember).

This Pull Request is to confirm our team's preferences, which is a prerequisite to merging ActionSprout/fern#3505