### PR TITLE
Establish Order Conventions for ember Routes

### DIFF
--- a/ember.md
+++ b/ember.md
@@ -553,15 +553,15 @@ links](https://ember-twiddle.com/0fea52795863b88214cb?numColumns=3).
 
 Routes should be grouped as follows:
 
-* Services
-* Default route's properties
-* Custom properties
-* beforeModel() hook
-* model() hook
-* afterModel() hook
-* Other lifecycle hooks in execution order (serialize, redirect, etc)
-* Actions
-* Custom / private methods
+1. Services
+1. Default route's properties
+1. Custom properties
+1. beforeModel() hook
+1. model() hook
+1. afterModel() hook
+1. Other lifecycle hooks in execution order (serialize, redirect, etc)
+1. Actions
+1. Custom / private methods
 
 ```
 const { Route, inject: { service }, get } = Ember;

--- a/ember.md
+++ b/ember.md
@@ -403,6 +403,75 @@ export default DS.Model.extend({
 
 ```
 
+## Routes
+
+### Organization
+
+Routes should be grouped as follows:
+
+* Services
+* Default route's properties
+* Custom properties
+* beforeModel() hook
+* model() hook
+* afterModel() hook
+* Other lifecycle hooks in execution order (serialize, redirect, etc)
+* Actions
+* Custom / private methods
+
+```
+const { Route, inject: { service }, get } = Ember;
+
+export default Route.extend({
+  // 1. Services
+  currentUser: service(),
+
+  // 2. Default route's properties
+  queryParams: {
+    sortBy: { refreshModel: true },
+  },
+
+  // 3. Custom properties
+  customProp: 'test',
+
+  // 4. beforeModel hook
+  beforeModel() {
+    if (!get(this, 'currentUser.isAdmin')) {
+      this.transitionTo('index');
+    }
+  },
+  
+  // 5. model hook
+  model() {
+    return this.store.findAll('article');
+  },
+  
+  // 6. afterModel hook
+  afterModel(articles) {
+    articles.forEach((article) => {
+      article.set('foo', 'bar');
+    });
+  },
+
+  // 7. Other route's methods
+  setupController(controller) {
+    controller.set('foo', 'bar');
+  },
+
+  // 8. All actions
+  actions: {
+    sneakyAction() {
+      return this._secretMethod();
+    },
+  },
+
+  // 9. Custom / private methods
+  _secretMethod() {
+    // custom secret method logic
+  },
+});
+```
+
 ## Controllers
 
 ### Define query params first

--- a/ember.md
+++ b/ember.md
@@ -403,75 +403,6 @@ export default DS.Model.extend({
 
 ```
 
-## Routes
-
-### Organization
-
-Routes should be grouped as follows:
-
-* Services
-* Default route's properties
-* Custom properties
-* beforeModel() hook
-* model() hook
-* afterModel() hook
-* Other lifecycle hooks in execution order (serialize, redirect, etc)
-* Actions
-* Custom / private methods
-
-```
-const { Route, inject: { service }, get } = Ember;
-
-export default Route.extend({
-  // 1. Services
-  currentUser: service(),
-
-  // 2. Default route's properties
-  queryParams: {
-    sortBy: { refreshModel: true },
-  },
-
-  // 3. Custom properties
-  customProp: 'test',
-
-  // 4. beforeModel hook
-  beforeModel() {
-    if (!get(this, 'currentUser.isAdmin')) {
-      this.transitionTo('index');
-    }
-  },
-  
-  // 5. model hook
-  model() {
-    return this.store.findAll('article');
-  },
-  
-  // 6. afterModel hook
-  afterModel(articles) {
-    articles.forEach((article) => {
-      article.set('foo', 'bar');
-    });
-  },
-
-  // 7. Other route's methods
-  setupController(controller) {
-    controller.set('foo', 'bar');
-  },
-
-  // 8. All actions
-  actions: {
-    sneakyAction() {
-      return this._secretMethod();
-    },
-  },
-
-  // 9. Custom / private methods
-  _secretMethod() {
-    // custom secret method logic
-  },
-});
-```
-
 ## Controllers
 
 ### Define query params first
@@ -617,6 +548,73 @@ this.route('foo', { path: ':fooId' });
 
 [Example with broken
 links](https://ember-twiddle.com/0fea52795863b88214cb?numColumns=3).
+
+### Organization
+
+Routes should be grouped as follows:
+
+* Services
+* Default route's properties
+* Custom properties
+* beforeModel() hook
+* model() hook
+* afterModel() hook
+* Other lifecycle hooks in execution order (serialize, redirect, etc)
+* Actions
+* Custom / private methods
+
+```
+const { Route, inject: { service }, get } = Ember;
+
+export default Route.extend({
+  // 1. Services
+  currentUser: service(),
+
+  // 2. Default route's properties
+  queryParams: {
+    sortBy: { refreshModel: true },
+  },
+
+  // 3. Custom properties
+  customProp: 'test',
+
+  // 4. beforeModel hook
+  beforeModel() {
+    if (!get(this, 'currentUser.isAdmin')) {
+      this.transitionTo('index');
+    }
+  },
+  
+  // 5. model hook
+  model() {
+    return this.store.findAll('article');
+  },
+  
+  // 6. afterModel hook
+  afterModel(articles) {
+    articles.forEach((article) => {
+      article.set('foo', 'bar');
+    });
+  },
+
+  // 7. Other route's methods
+  setupController(controller) {
+    controller.set('foo', 'bar');
+  },
+
+  // 8. All actions
+  actions: {
+    sneakyAction() {
+      return this._secretMethod();
+    },
+  },
+
+  // 9. Custom / private methods
+  _secretMethod() {
+    // custom secret method logic
+  },
+});
+```
 
 ## Ember Data
 


### PR DESCRIPTION
These conventions will be re-asserted by ESLint (https://github.com/ember-cli/eslint-plugin-ember).

For reference, ESLint's default `config` is as follows: 
```
ember/order-in-routes: [2, {
  order: [
    'service',
    'inherited-property',
    'property',
    'single-line-function',
    'multi-line-function',
    'beforeModel',
    'model',
    'afterModel',
    'serialize',
    'redirect',
    'activate',
    'setupController',
    'renderTemplate',
    'resetController',
    'deactivate',
    'actions',
    ['method', 'empty-method'],
  ]
}]
``` 

This Pull Request is to confirm our team's preferences, which is a prerequisite to updating our ember route style conventions (https://www.pivotaltracker.com/story/show/150684734) .