### PR TITLE
Add an elixir styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@
   <sup>[original source](https://github.com/elierotenberg/coding-styles)</sup>
 - [PostgreSQL coding guidelines](postgres.md)
   <sup>[original source](https://github.com/elierotenberg/coding-styles)</sup>
+- [Elixir coding guidelines](https://github.com/rrrene/elixir-style-guide)
+  <sup>Not in this repo until we need to make changes</sup>


### PR DESCRIPTION
This is actually just a link to another styleguide. I am not sure it makes sense to copy that one in here until we have some need to make changes.

The style guide is here: https://github.com/rrrene/elixir-style-guide

One reason I chose this style guide is that it has a good looking tool to enforce it. I will be installing https://github.com/rrrene/credo and trying it out tomorrow.